### PR TITLE
Add deleting objects if no text - fix #13.

### DIFF
--- a/src/main/fsm.js
+++ b/src/main/fsm.js
@@ -275,28 +275,35 @@ document.onkeydown = function(e) {
 		return true;
 	} else if(key == 8) { // backspace key
 		if(selectedObject != null && 'text' in selectedObject) {
-			selectedObject.text = selectedObject.text.substr(0, selectedObject.text.length - 1);
-			resetCaret();
-			draw();
+			if(selectedObject.text) {
+				selectedObject.text = selectedObject.text.substr(0, selectedObject.text.length - 1);
+				resetCaret();
+				draw();
+			} else {
+				removeSelectedObject();
+			}
 		}
 
 		// backspace is a shortcut for the back button, but do NOT want to change pages
 		return false;
 	} else if(key == 46) { // delete key
 		if(selectedObject != null) {
-			for(var i = 0; i < nodes.length; i++) {
-				if(nodes[i] == selectedObject) {
-					nodes.splice(i--, 1);
-				}
-			}
-			for(var i = 0; i < links.length; i++) {
-				if(links[i] == selectedObject || links[i].node == selectedObject || links[i].nodeA == selectedObject || links[i].nodeB == selectedObject) {
-					links.splice(i--, 1);
-				}
-			}
-			selectedObject = null;
-			draw();
+			removeSelectedObject();
 		}
+	}
+	function removeSelectedObject() {
+		for(var i = 0; i < nodes.length; i++) {
+			if(nodes[i] == selectedObject) {
+				nodes.splice(i--, 1);
+			}
+		}
+		for(var i = 0; i < links.length; i++) {
+			if(links[i] == selectedObject || links[i].node == selectedObject || links[i].nodeA == selectedObject || links[i].nodeB == selectedObject) {
+				links.splice(i--, 1);
+			}
+		}
+		selectedObject = null;
+		draw();
 	}
 };
 


### PR DESCRIPTION
This fixes inability to delete objects on mac since the delete key sends a backspace key code, laptops don't have a real delete, and even with karabiner it's not possible to set some key to a real delete.