### PR TITLE
Hotfix for export as png

### DIFF
--- a/src/main/fsm.js
+++ b/src/main/fsm.js
@@ -373,6 +373,14 @@ function saveAsPNG() {
 	drawUsing(canvas.getContext('2d'));
 	selectedObject = oldSelectedObject;
 	var pngData = canvas.toDataURL('image/png');
+	
+	// Fallback on Chromium based browsers
+    	var downloadLink = document.createElement('a');
+    	downloadLink.download = 'fsm.png';
+    	downloadLink.href = document.getElementById('canvas').toDataURL();
+    	downloadLink.click();
+	
+	// This works on FireFox
 	document.location.href = pngData;
 }
 


### PR DESCRIPTION
Exporting PNGs seems to be broken on Chromium based browsers (it works on Firefox), and it's already mentioned in issue #22.

![image](https://user-images.githubusercontent.com/60794869/171998540-8d44de84-f908-47ab-af90-7dd27c2230bc.png)

_Photo taken from Microsoft Edge version 102.0.1245.30 (Official build) (64-bit)_

So I implemented a simple workaround for this. The solution is in `function saveAsPNG()` on line 370, and the other lines that are mentioned in the diff are due to line-ending differences (I didn't know how to fix them, sorry).